### PR TITLE
Better messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val `sbt-compatibility` = project
       "io.github.alexarchambault" %% "data-class" % "0.2.3" % Provided,
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
     ),
-    libraryDependencies += "io.get-coursier" %% "versions" % "0.2.0",
+    libraryDependencies += "io.get-coursier" %% "versions" % "0.2.1",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.4" % Test,
     testFrameworks += new TestFramework("utest.runner.Framework")
   )

--- a/src/main/scala/sbtcompatibility/DependencyCheckReport.scala
+++ b/src/main/scala/sbtcompatibility/DependencyCheckReport.scala
@@ -27,7 +27,7 @@ import sbtcompatibility.internal.Version
 
     def message(org: String, name: String, backward: Boolean, status: DependencyCheckReport.ModuleStatus): String = {
       val direction = if (backward) "backward" else "forward"
-      s"$org:$name ($direction): ${status.message}"
+      s"$org:$name: ${status.message}"
     }
 
     val actualErrors = baseErrors.collect {
@@ -50,16 +50,16 @@ object DependencyCheckReport {
     def message: String
   }
   @data class SameVersion(version: String) extends ModuleStatus(true) {
-    def message = s"same version: $version"
+    def message = s"found same version $version"
   }
   @data class CompatibleVersion(version: String, previousVersion: String, reconciliation: VersionCompatibility) extends ModuleStatus(true) {
-    def message = s"compatible versions: $previousVersion -> $version ($reconciliation)"
+    def message = s"compatible version change from $previousVersion to $version (compatibility: ${reconciliation.name})"
   }
   @data class IncompatibleVersion(version: String, previousVersion: String, reconciliation: VersionCompatibility) extends ModuleStatus(false) {
-    def message = s"incompatible versions: $previousVersion -> $version ($reconciliation)"
+    def message = s"incompatible version change from $previousVersion to $version (compatibility: ${reconciliation.name})"
   }
   @data class Missing(version: String) extends ModuleStatus(false) {
-    def message = s"missing (former version: $version)"
+    def message = "missing dependency"
   }
 
 


### PR DESCRIPTION
Needs the upcoming `io.get-coursier::versions:0.2.1`, including https://github.com/coursier/versions/pull/2.